### PR TITLE
feat(go): add equals after var name

### DIFF
--- a/queries/go/tsetter.scm
+++ b/queries/go/tsetter.scm
@@ -1,0 +1,12 @@
+;; --------------
+;; Variables
+;; --------------
+;; Go variable declaration
+;; Example:
+;;      var a = 1
+;;      var b = "hello"
+(var_declaration
+  (var_spec 
+    name: (identifier) 
+    type: (type_identifier) @equals
+    )) 


### PR DESCRIPTION
Add initial support for go #2 

This works for simple variable declaration with initialization:
```go
func main() {
  var a = 1
  //    ^- this would automatically be inserted
}

```